### PR TITLE
Bug fixes read merging

### DIFF
--- a/src/main/java/Modules/preprocessing/ClipAndMerge.java
+++ b/src/main/java/Modules/preprocessing/ClipAndMerge.java
@@ -87,7 +87,7 @@ public class ClipAndMerge extends AModule {
         return new String[]{"ClipAndMerge", "-in1",  getForwards(), "-in2", getReverse(),
                 "-f", this.communicator.getMerge_fwadaptor(), "-r", this.communicator.getMerge_bwadaptor(),
                 "-l", String.valueOf(this.communicator.getQuality_readlength()),"-no_merging", "-qt", "-q", String.valueOf(this.communicator.getQuality_minreadquality()),
-                "-log", getOutputfolder()+ "stats.log", String.valueOf(this.communicator.getMerge_min_adapter_overlap()),
+                "-log", getOutputfolder()+ "stats.log", "-m", String.valueOf(this.communicator.getMerge_min_adapter_overlap()),
                 this.communicator.getMerge_advanced(),
                 "-o ", getOutputfolder() +output_stem+".clipped.fq.gz", "-u", getOutputfolder()+output_stem+".forwards.fq.gz", getOutputfolder()+output_stem+".reverse.fq.gz"};
 

--- a/src/main/java/Runner/RunEAGER.java
+++ b/src/main/java/Runner/RunEAGER.java
@@ -793,7 +793,8 @@ public class RunEAGER {
      * --> depending on this we decide if sampe or samse have to be used.
      */
     private void addBWAMapping(ModulePool pooltoadd) {
-        if (communicator.getMerge_type().equals("PAIRED") && communicator.isRun_clipandmerge() && communicator.isMerge_only_clipping()) {
+        if (communicator.getMerge_type().equals("PAIRED") && ((communicator.isRun_clipandmerge() && communicator.isMerge_only_clipping())
+                || !communicator.isRun_clipandmerge())) {
             pooltoadd.addModule(new BWAAlign(communicator, BWAAlign.PAIREDENDWITHOUTMERGING));
             pooltoadd.addModule(new BWASampe(communicator));
         } else {
@@ -909,7 +910,8 @@ public class RunEAGER {
      */
 
     private void addBWAMemMapping(ModulePool pooltoadd) {
-        if (communicator.isPairmenttype() && !communicator.isRun_clipandmerge()) {
+        if (communicator.getMerge_type().equals("PAIRED") && ((communicator.isRun_clipandmerge() && communicator.isMerge_only_clipping())
+                || !communicator.isRun_clipandmerge())) {
             pooltoadd.addModule(new BWAMem(communicator, BWAMem.PAIREDENDWITHOUTMERGE));
         } else {
             pooltoadd.addModule(new BWAMem(communicator));

--- a/src/main/java/Runner/RunEAGER.java
+++ b/src/main/java/Runner/RunEAGER.java
@@ -1120,10 +1120,10 @@ public class RunEAGER {
                 if(!communicator.isMerge_only_clipping()){
                     toadd.addModule(new AdapterRemoval(communicator));
                     toadd.addModule(new CombineFastQ(communicator));
+                    toadd.addModule(new AdapterRemovalFixReadPrefix(communicator));
                 } else {
                     toadd.addModule(new AdapterRemoval(communicator, AdapterRemoval.ADAPTER_CLIPPING_ONLY));
                 }
-                toadd.addModule(new AdapterRemovalFixReadPrefix(communicator));
             } else {
                 toadd.addModule(new AdapterRemoval(communicator, AdapterRemoval.SINGLE_ENDED_ONLY));
             }


### PR DESCRIPTION
Fixed 3 Bugs:
- In Clip and Merge the -m parameter was not set leading to a command that was not runnable
- The if statement in addBWAMemMapping was not correct, leading to the program not running if only clipping was selected -> changed the if statement (for addBWAMapping as well, for completeness)
- The files were prefixed after only clipping so bwa mem could not run because it needs the forward and reverse reads to have the same name -> only run the prefix module if reads are merged